### PR TITLE
feat: add ready-to-test command and independent container registry

### DIFF
--- a/.github/workflows/chatops-dispatcher.yml
+++ b/.github/workflows/chatops-dispatcher.yml
@@ -10,12 +10,15 @@ jobs:
         github.event.issue.pull_request &&
         (
           startsWith(github.event.comment.body, '/test') ||
-          startsWith(github.event.comment.body, '/ok-to-merge')
+          startsWith(github.event.comment.body, '/ok-to-merge') ||
+          startsWith(github.event.comment.body, '/ready-to-test')
+
         )
     runs-on: ubuntu-20.04
     steps:
       - name: Run E2E on CNPG
         uses: peter-evans/slash-command-dispatch@v3
+        if: ${{ startsWith(github.event.comment.body, '/test') }}
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
           issue-type: pull-request
@@ -25,9 +28,25 @@ jobs:
           static-args: |
             test_level=4
             depth=main
+
       - name: Add "ok to merge" label to CNPG PR
         uses: actions-ecosystem/action-add-labels@v1.1.3
         if: ${{ startsWith(github.event.comment.body, '/ok-to-merge') }}
         with:
            github_token: ${{ secrets.REPO_GHA_PAT }}
            labels: "ok to merge :ok_hand:"
+
+      - name: Remove "ready to test :elephant:" label if exists
+        uses: actions-ecosystem/action-remove-labels@v1.3.0
+        if: |
+          startsWith(github.event.comment.body, '/ready-to-test') &&
+          contains(github.event.pull_request.labels.*.name, 'ready to test :elephant:')
+        with:
+          github_token: ${{ secrets.REPO_GHA_PAT }}
+          labels: "ready to test :elephant:"
+
+      - name: Add "ready to test" label to CNPG PR
+        uses: actions-ecosystem/action-add-labels@v1.1.3
+        with:
+           github_token: ${{ secrets.REPO_GHA_PAT }}
+           labels: "ready to test :elephant:"

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - '**'
   pull_request:
+  pull_request_target:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       depth:
@@ -23,6 +25,7 @@ env:
   KUBEBUILDER_VERSION: "2.3.1"
   KIND_VERSION: "v0.11.0"
   ROOK_VERSION: "v1.6.8"
+  CNPG_IMAGE_NAME: "ghcr.io/${{ github.repository }}-testing"
 
 defaults:
   run:
@@ -149,6 +152,10 @@ jobs:
       (
         needs.change-triage.outputs.operator-changed == 'true' ||
         needs.change-triage.outputs.go-code-changed == 'true'
+      ) &&
+      (
+        github.event.client_payload.slash_command != null ||
+        contains(github.event.pull_request.labels.*.name, 'ready to test :elephant:')
       )
     runs-on: ubuntu-20.04
     strategy:
@@ -312,7 +319,7 @@ jobs:
         name: Build meta
         id: build-meta
         run: |
-          images='ghcr.io/cloudnative-pg/cloudnative-pg-testing'
+          images='${{ env.CNPG_IMAGE_NAME }}'
           tags=''
           labels=''
           commit_sha=${{ github.event.pull_request.head.sha || github.sha }}


### PR DESCRIPTION
We introduce a new behaviour in this commit:

1.- The commits now can run in the forked repo, using the external
    user registry to push the image and the run the E2E.
2.- A new command `ready-to-test` that use the `pull_request_target`
    event to run the test and run the E2E test on the PR, this will
    allow forked repo to run test from the PR when a user allows it.

Peevioulsy we were not avaible to run the E2E on PR from forked repo
due to the fixed use of the cloudnative-pg repo and since the
`pull_request` event doesn't provide a GitHub token with write permissions
for packages.

We still allow running E2E test from internal branch only when the `test`
command is used, since it will trigger the event dispatch with the client
payload and is used to verify that comes from the internal repo.

Closes #426

Signed-off-by: Jonathan Gonzalez V <jonathan.gonzalez@enterprisedb.com>